### PR TITLE
feat(agent): fetch_reflection_signals + post_reflection (v0.10.0)

### DIFF
--- a/src/cosmergon_agent/__init__.py
+++ b/src/cosmergon_agent/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"
 
 if TYPE_CHECKING:
     # CosmergonAgent is lazy-loaded at runtime via __getattr__ to avoid

--- a/src/cosmergon_agent/agent.py
+++ b/src/cosmergon_agent/agent.py
@@ -412,6 +412,111 @@ class CosmergonAgent:
             pass
         return ""
 
+    async def fetch_reflection_signals(self, horizon: str = "short") -> dict | None:
+        """Fetch the data an external LLM needs to synthesize a self_reflection.
+
+        Companion to ``post_reflection``. The two together let api-Agents
+        (Pet, SDK-bots, MCP, Dashboard with LLM) run their own reflection
+        loop using their own LLM/SLM — Cosmergon is only the data store.
+
+        See ``docs/konzepte/konzept-api-agent-reflection.md`` for why this
+        path exists separately from the in-Cosmergon NPC reflection: api-
+        Agents must use their own external LLM (per memory directive
+        ``feedback_non_npc_merken_und_externe_llm``), so Cosmergon exposes
+        the data and the write-back instead of running a second LLM.
+
+        Args:
+            horizon: ``"short"`` (default, ~10-tick window), ``"mid"``,
+                or ``"long"``. Matches NPC reflection horizons.
+
+        Returns:
+            ``{top_5, bottom_5, dominant_actions, decisions_in_window,
+            since_tick, horizon}`` or ``None`` on transient server error /
+            older backend without the endpoint. Empty top/bottom lists are
+            normal for agents with few decisions yet — caller should skip
+            the LLM call in that case and try again next tick.
+
+        Typical usage (Pet/SDK-bot)::
+
+            state = await agent.refresh_state()
+            if state.reflection_due:
+                signals = await agent.fetch_reflection_signals()
+                if signals and (signals["top_5"] or signals["bottom_5"]):
+                    payload = my_llm.synthesize_reflection(signals)
+                    await agent.post_reflection(payload, since_tick=signals["since_tick"])
+        """
+        try:
+            resp = await self._request(
+                "GET",
+                f"/api/v1/agents/{self.agent_id}/reflection/signals",
+                params={"horizon": horizon},
+            )
+            if resp.status_code == 200:
+                return resp.json()  # type: ignore[no-any-return]
+        except Exception:
+            pass
+        return None
+
+    async def post_reflection(
+        self,
+        lessons: str,
+        avoid: str,
+        double_down: str,
+        *,
+        since_tick: int,
+        horizon: str = "short",
+        model_used: str | None = None,
+    ) -> dict | None:
+        """Persist an externally-synthesized self_reflection on the agent.
+
+        Companion to ``fetch_reflection_signals``. The caller has run
+        their own LLM against the signals and produces three structured
+        strings (lessons / avoid / double_down). This method posts them
+        back; the backend validates length-bounds against its
+        ``ReflectionResult`` schema and writes a ``self_reflection`` event
+        with importance_score=1.0 (never evicted until decay).
+
+        Length bounds match the NPC schema for parity:
+            - lessons: 100-500 chars
+            - avoid: 50-200 chars
+            - double_down: 50-200 chars
+
+        Args:
+            lessons: synthesized lesson, 100-500 chars
+            avoid: anti-pattern to avoid, 50-200 chars
+            double_down: confirmed strength to double down on, 50-200 chars
+            since_tick: tick_number returned by ``fetch_reflection_signals``,
+                so the backend can record the reflection's window
+            horizon: ``"short"`` / ``"mid"`` / ``"long"`` — must match the
+                horizon used to fetch signals
+            model_used: free-text identifier of the model that produced the
+                synthesis (e.g. ``"ollama/llama3.2:3b"``). Stored as audit
+                trail and visible in the benchmark service.
+
+        Returns:
+            ``{event_id, tick_number, horizon}`` on success, ``None`` on
+            transient server error. 422 (length validation) raises
+            ``CosmergonError`` so caller can react.
+        """
+        try:
+            resp = await self._request(
+                "POST",
+                f"/api/v1/agents/{self.agent_id}/reflection",
+                json={
+                    "lessons": lessons,
+                    "avoid": avoid,
+                    "double_down": double_down,
+                    "since_tick": since_tick,
+                    "horizon": horizon,
+                    "model_used": model_used,
+                },
+            )
+            if resp.status_code == 200:
+                return resp.json()  # type: ignore[no-any-return]
+        except Exception:
+            pass
+        return None
+
     async def get_last_decision(self) -> dict | None:
         """Fetch the most recent LLM decision for this agent.
 

--- a/src/cosmergon_agent/state.py
+++ b/src/cosmergon_agent/state.py
@@ -155,6 +155,13 @@ class GameState:
     learned_rules: list[str] = field(default_factory=list)
     next_tick_at: float | None = None  # Unix timestamp when next game tick fires (server truth)
     compass_preset: str | None = None  # Last explicitly set compass preset; None if never set
+    # api-Agent-Reflexion (Cosmergon backend ≥ v1.60.862, S161 2026-05-04):
+    # backend signals when the agent has accumulated enough decisions for the
+    # external LLM-Decider to run a self-reflection round. Pet/SDK-bot reads
+    # this and calls `await agent.reflect(provider)` when set. Older backends
+    # leave both fields at the defaults below — `reflect()` is then a no-op.
+    reflection_due: bool = False
+    decisions_since_last_reflection: int = 0
 
     @classmethod
     def from_api(cls, data: dict) -> GameState:
@@ -192,4 +199,6 @@ class GameState:
             learned_rules=data.get("learned_rules", []),
             next_tick_at=data.get("next_tick_at"),
             compass_preset=data.get("compass_preset"),
+            reflection_due=bool(data.get("reflection_due", False)),
+            decisions_since_last_reflection=int(data.get("decisions_since_last_reflection", 0)),
         )


### PR DESCRIPTION
Companion methods for the new Cosmergon reflection API (backend v1.60.862, S161). api-Agents (Pet, SDK-bots, MCP, Dashboard) can now run their own self-reflection loop using their own external LLM.

Per directive feedback_non_npc_merken_und_externe_llm: split as fetch+post so inference stays with the caller (own LLM/SLM), Cosmergon is just the data store. GameState extended with reflection_due + decisions_since_last_reflection (defensive parsing, older backends default to False/0).

Tests: 4 new in TestReflection. Lint + whitelist clean.

Version: 0.10.0 (minor, additive). PyPI publish post-merge via workflow_dispatch.